### PR TITLE
Update versioning

### DIFF
--- a/.github/workflows/lili.yml
+++ b/.github/workflows/lili.yml
@@ -21,7 +21,6 @@ jobs:
            cd C:\"Program Files (x86)"\AutoIt3\Aut2Exe
            git clone https://github.com/rcmaehl/LinuxLiveUSBCreator
            cd LinuxLiveUSBCreator
-           $ver= git describe --always
            Move-Item * ..
     - name: Install Autoit Code Stripper
       run: |
@@ -30,8 +29,11 @@ jobs:
     - name: Compile
       run: |
            cd C:\"Program Files (x86)"\AutoIt3\Aut2Exe
+           cd LinuxLiveUSBCreator
+           $ver= git rev-list --count HEAD
+           cd ..
            mkdir build
-           ./Aut2exe.exe /in "sources\LiLi\LiLi USB Creator.au3" /out build\LiLiUSBCreator$ver.exe /nopack /icon tools\img\lili.ico /comp 4 /x64
+           ./Aut2exe.exe /in "sources\LiLi\LiLi USB Creator.au3" /out build\LiLiUSBCreator-2.10alpha$ver.exe /nopack /icon tools\img\lili.ico /comp 4 /x64
            Start-Sleep -s 10
            Move-Item tools build
     - name: Upload


### PR DESCRIPTION
I just changed it to 2.10alpha, last version was 2.9.xx.xx, it doesnt really come over with the one specified using Autoit3wrapper but I think it is good enough, and easy to see that for example 2.10alpha77 is higher number than 2.10alpha72

![image](https://user-images.githubusercontent.com/45581170/116117272-541a3c00-a6bc-11eb-84d3-874fb2f04a25.png)
